### PR TITLE
Fix webpack.config.js to ignore ts test files

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -22,10 +22,5 @@
       "@containers/*": ["src/views/containers/*"],
       "@pages/*": ["src/views/pages/*"]
     }
-  },
-  "exclude": [
-    "node_modules",
-    "**/*.test.ts",
-    "jest.setup.ts"
-  ]
+  }
 }

--- a/client/tsconfig.webpack.json
+++ b/client/tsconfig.webpack.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "exclude": [
+    "jest.setup.ts",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "node_modules"
+  ]
+}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -10,36 +10,41 @@ module.exports = env => {
     mode: "development",
 
     entry: client_path + "/src/index.tsx",
-  
+
     output: {
       path: path.resolve(public_path, "js"),
       filename: "bundle.js",
       publicPath: "js"
     },
-  
+
     devtool: 'source-map',
-  
+
     module: {
       rules: [
         {
           test: /\.tsx?$/,
-          use: "ts-loader"
+          loader: "ts-loader",
+          // use tsconfig.webpack.json to ignore test files.
+          // ref: https://github.com/TypeStrong/ts-loader/issues/544
+          options: {
+            configFile: "tsconfig.webpack.json"
+          }
         }
       ]
     },
-  
+
     resolve: {
       extensions: [".ts", ".tsx", ".js", ".json"],
       // ref: https://github.com/TypeStrong/ts-loader#baseurl--paths-module-resolution
       plugins: [new TsconfigPathsPlugin({ configFile: "./tsconfig.json" })]
     },
-  
+
     plugins: [
       new webpack.DefinePlugin({
         "CONFIG_TYPE": JSON.stringify((env && env.config) ? env.config : "dev")
       })
     ],
-  
+
     devServer: {
       port: 3000,
       contentBase: public_path,
@@ -47,7 +52,7 @@ module.exports = env => {
       watchContentBase: true,
       historyApiFallback: true
     },
-  
+
     watchOptions: {
       aggregateTimeout: 300,
       ignored: /node_modules/


### PR DESCRIPTION
The behavior of Visual Studio Code IntelliSense for Typescript is based on tsconfig. If test files is excluded by tsconfig, the conditions described in tsconfig are not applied to test files during development. So create a tsconfig for webpack and exclude test files only at build time.
