### PR TITLE
Change middlewares order

### DIFF
--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -13,7 +13,7 @@ import {
 import eventsReducer from "./events";
 
 export const history = createBrowserHistory();
-const middlewares = [logger, routerMiddleware(history), thunk];
+const middlewares = [thunk, logger, routerMiddleware(history)];
 const rootReducer = combineReducers({
   notesState: notesReducer,
   authState: authReducer,


### PR DESCRIPTION
move thunk first in the middlewares to prevent asynchronous actions from being logged